### PR TITLE
Removed the Polynomials dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,12 @@ version = "0.6.0"
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
 DataDeps = "0.7"
 FITSIO = "0.13.0, 0.14"
-Polynomials = "0.8"
 Unitful = "0.17.0, 1"
 UnitfulAstro = "0.3.0, 0.4, 1"
 julia = "1.0.0"

--- a/src/color_laws.jl
+++ b/src/color_laws.jl
@@ -1,4 +1,4 @@
-using Polynomials, Unitful, UnitfulAstro
+using Unitful, UnitfulAstro
 
 # Convenience function for wavelength conversion
 aa_to_invum(wave::Real) = 10000 / wave
@@ -7,11 +7,11 @@ aa_to_invum(wave::Quantity) = aa_to_invum(ustrip(u"angstrom", wave))
 #--------------------------------------------------------------------------------
 
 # Optical coefficients
-const ccm89_ca = Poly([1.0, 0.17699, -0.50447, -0.02427, 0.72085, 0.01979, -0.7753, 0.32999])
-const ccm89_cb = Poly([0.0, 1.41338, 2.28305, 1.07233, -5.38434, -0.62251, 5.3026, -2.09002])
+const ccm89_ca = [1.0, 0.17699, -0.50447, -0.02427, 0.72085, 0.01979, -0.7753, 0.32999, 0.0]
+const ccm89_cb = [0.0, 1.41338, 2.28305, 1.07233, -5.38434, -0.62251, 5.3026, -2.09002, 0.0]
 
-const od94_ca = Poly([1.0, 0.104, -0.609, 0.701, 1.137, -1.718, -0.827, 1.647, -0.505])
-const od94_cb = Poly([0.0, 1.952, 2.908, -3.989, -7.985, 11.102, 5.491, -10.805, 3.347])
+const od94_ca = [1.0, 0.104, -0.609, 0.701, 1.137, -1.718, -0.827, 1.647, -0.505]
+const od94_cb = [0.0, 1.952, 2.908, -3.989, -7.985, 11.102, 5.491, -10.805, 3.347]
 
 """
     ccm89(λ::Real, Rv=3.1)
@@ -62,7 +62,7 @@ end
 
 od94(λ::Quantity, Rv = 3.1) = ccm89(ustrip(u"angstrom", λ), Rv) * u"mag"
 
-function ccm89_invum(x::Real, Rv::Real, c_a::Poly{<:Real}, c_b::Poly{<:Real})
+function ccm89_invum(x::Real, Rv::Real, c_a::Vector{<:Real}, c_b::Vector{<:Real})
     if x < 0.3
         return 0.0x
     elseif x < 1.1  # Near IR
@@ -72,8 +72,8 @@ function ccm89_invum(x::Real, Rv::Real, c_a::Poly{<:Real}, c_b::Poly{<:Real})
     elseif x < 3.3  # Optical
         y = x - 1.82
         yn = 1.0
-        a = c_a(y)
-        b = c_b(y)
+        a = @evalpoly y c_a[1] c_a[2] c_a[3] c_a[4] c_a[5] c_a[6] c_a[7] c_a[8] c_a[9]
+        b = @evalpoly y c_b[1] c_b[2] c_b[3] c_b[4] c_b[5] c_b[6] c_b[7] c_b[8] c_b[9]
     elseif x < 8.0  # NUV
         a =  1.752 - 0.316x - (0.104 / ((x - 4.67)^2 + 0.341))
         b = -3.090 + 1.825x + (1.206 / ((x - 4.62)^2 + 0.263))


### PR DESCRIPTION
Initially, there was only one function `ccm_invum` which was used for both `ccm89` and `od94` models. The only point of difference in these models was polynomial evaluations, so the polynomials were explicitly passed to the `ccm_invum` which lead to Polynomials as a dependency.
This PR creates two new functions (`ccm_invum` & `od94_invum`) to address this issue and in polynomial evaluation, `@evalpoly` is used. 