### PR TITLE
remove v1.0 patch

### DIFF
--- a/src/color_laws/fitzpatrick.jl
+++ b/src/color_laws/fitzpatrick.jl
@@ -207,9 +207,7 @@ function f04_invum(x::Real, Rv::Real)
         (@evalpoly Rv  1.208 1.0032 -0.00033)
 
     # updated NIR curve from F04, note R dependence
-    # Julia v1.0 workaround: https://github.com/JuliaAstro/DustExtinction.jl/pull/31#commitcomment-40605778
-    nir_axebv_y_coeff = (0.63 * Rv - 0.84)
-    nir_axebv_y = @. nir_axebv_y_coeff * f04_nir_axav_x^1.84
+    nir_axebv_y = @. (0.63 * Rv - 0.84) * f04_nir_axav_x^1.84
 
     optnir_axebv_y = @. (nir_axebv_y..., opt_axebv_y...) / Rv
 


### PR DESCRIPTION
Stumbled on [this old discussion here](https://github.com/JuliaAstro/DustExtinction.jl/pull/31#issuecomment-658453013). Since we have [moved on from Julia v1.0 now](https://github.com/JuliaAstro/DustExtinction.jl/commit/4517fe9259cb7ab0432c779d89c2c3e890231f16), I figured we can remove [this old workaround](https://github.com/JuliaAstro/DustExtinction.jl/pull/31/commits/e0882163150c0718ff26d8dde8bcf6e6d47238c2)

More context on the upstream bug-fix: https://github.com/JuliaLang/julia/pull/29843

tl;dr: Doing something like `@. (1*2) * (3, 4)` doesn't error in LTS Julia anymore, so we can drop the workaround we introduced for this

Love the new organization scheme for the color laws btw!