### PR TITLE
Support Makie 0.23, 0.24, bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DustExtinction"
 uuid = "fb44c06c-c62f-5397-83f5-69249e0a3c8e"
 license = "MIT"
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
@@ -20,7 +20,7 @@ MakieExt = "Makie"
 BSplineKit = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 DataDeps = "0.7"
 FITSIO = "0.13.0, 0.14, 0.15, 0.16.1, 0.17"
-Makie = "0.21.18, 0.22"
+Makie = "0.21.18, 0.22, 0.23, 0.24"
 Unitful = "0.17.0, 1"
 UnitfulAstro = "0.3.0, 0.4, 1"
 julia = "1.6"


### PR DESCRIPTION
This combines #74, #75. Tests pass and PR preview docs look good.