### PR TITLE
Allow precompiling in buildpkg step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
+        with:
+          precompile: yes
       - uses: julia-actions/julia-runtest@v1
         env:
           DATADEPS_ALWAYS_ACCEPT: true


### PR DESCRIPTION
Just to minimize log lines in the actual testing step, so that test failures are easier to inspect